### PR TITLE
Fixes #3

### DIFF
--- a/Maths/Algebra/Quasigroup.idr
+++ b/Maths/Algebra/Quasigroup.idr
@@ -1,9 +1,9 @@
 module Maths.Algebra.Quasigroup
 
-||| A magma with unique left and right division, that is
+||| A magma with left and right division, that is
 |||   + forall a,b 
-|||          a `op` (rinverse a) = b
-|||          (linverse a) `op` a = b
+|||          a `op` (a `qunder` b) = b
+|||          (b `qover` a) `op` a = b
 class Magma a => Quasigroup a where
-  rinverse : a -> a
-  linverse : a -> a
+  qunder : a -> a -> a
+  qover : a -> a -> a


### PR DESCRIPTION
Quasigroups: Binary division operators `qunder` and `qover` replacing unary inverse operators `linverse` and `rinverse`.
